### PR TITLE
テーブル定義書からモデル（DB）を作成できる様にする。

### DIFF
--- a/app/models/book_rental_status.rb
+++ b/app/models/book_rental_status.rb
@@ -1,0 +1,2 @@
+class BookRentalStatus < ApplicationRecord
+end

--- a/db/migrate/20170109045417_create_book_rental_statuses.rb
+++ b/db/migrate/20170109045417_create_book_rental_statuses.rb
@@ -1,0 +1,14 @@
+class CreateBookRentalStatuses < ActiveRecord::Migration[5.0]
+  def change
+    create_table :book_rental_statuses do |t|
+      t.integer :bookId
+      t.integer :userId
+      t.integer :status
+      t.date :lentFrom
+      t.date :scheduledLentTo
+      t.date :lentTo
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161103075630) do
+ActiveRecord::Schema.define(version: 20170109045417) do
+
+  create_table "book_rental_statuses", force: :cascade do |t|
+    t.integer  "bookId"
+    t.integer  "userId"
+    t.integer  "status"
+    t.date     "lentFrom"
+    t.date     "scheduledLentTo"
+    t.date     "lentTo"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
 
   create_table "sampledbs", force: :cascade do |t|
     t.string   "name"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,3 +8,7 @@
 Sampledb.create(:name => 'taro', :age => 20)
 Sampledb.create(:name => 'jiro', :age => 25)
 Sampledb.create(:name => 'hanako', :age => 30)
+# サンプルデータ(BookRentalStatus)
+BookRentalStatus.create(:bookId => 1, :userId => 1, :status => 1, :lentFrom => '2016-12-01', :scheduledLentTo => '2017-01-01', :lentTo => '2017-01-01')
+BookRentalStatus.create(:bookId => 2, :userId => 2, :status => 2, :lentFrom => '2016-12-01', :scheduledLentTo => '2017-01-01', :lentTo => '2017-01-01')
+BookRentalStatus.create(:bookId => 3, :userId => 3, :status => 3, :lentFrom => '2016-12-01', :scheduledLentTo => '2017-01-01', :lentTo => '2017-01-01')

--- a/test/fixtures/book_rental_statuses.yml
+++ b/test/fixtures/book_rental_statuses.yml
@@ -1,0 +1,19 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  id: 
+  bookId: 1
+  userId: 1
+  status: 1
+  lentFrom: 2017-01-09
+  scheduledLentTo: 2017-01-09
+  lentTo: 2017-01-09
+
+two:
+  id: 
+  bookId: 1
+  userId: 1
+  status: 1
+  lentFrom: 2017-01-09
+  scheduledLentTo: 2017-01-09
+  lentTo: 2017-01-09

--- a/test/models/book_rental_status_test.rb
+++ b/test/models/book_rental_status_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class BookRentalStatusTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Wikiに作成してくれたテーブル定義書をベースにモデル（DB）を作成できる様に追加しました〜。

作り方は #1 に記載しているので、このブランチに対して、必要なテーブルをAPI作成時に追加してもらえればと思います:)